### PR TITLE
Updates minus sign when initialiting switchers out and dropping the "if d_sq_int_XX==`l'" condition when summing the parts for the placebo variance estimates.nce 

### DIFF
--- a/Stata/did_multiplegt_dyn.ado
+++ b/Stata/did_multiplegt_dyn.ado
@@ -9,13 +9,17 @@
 ** Subsections may contain unnumbered subsubsections, tagged with "//".
 ** Subsubsections may be further divided into paragraphs, tagged with "*".
 ** Comments are also tagged with "*".
-** This version : April 19th, 2025
+** This version : April 28th, 2025
 
 ** This version includes Diego's changes:
 **** Fixes to variance estimation with controls() (tks)
 **** Fixes to same_switchers() and same_switchers_pl() with unbalanced panel
 **** Fixes to controls() with unbalanced panel
 **** no_updates turned into _no_updates
+
+** Felix:
+**** Delete if d_sq_int_XX==`l' condition when summing placebo variances 
+**** Adjust - when storing the switcher out variances
 
 ********************************************************************************
 *                                 PROGRAM 1                                    *
@@ -1532,7 +1536,8 @@ if "`trends_lin'"!=""{
 if N0_`i'_XX!=0{
 		replace U_Gg`i'_minus_XX = - U_Gg`i'_XX
 		replace count`i'_minus_XX= count`i'_core_XX
-		replace U_Gg_var_`i'_out_XX=U_Gg`i'_var_XX
+		//// CHANGE BELOW - tks (add minus sign)
+		replace U_Gg_var_`i'_out_XX= - U_Gg`i'_var_XX
 		scalar N0_`i'_XX_new=N0_`i'_XX
 		
 		if "`normalized'"!=""{
@@ -4943,7 +4948,7 @@ gen combined_pl`=increase_XX'_temp_`l'_`j'_`i'_XX=M_pl`=increase_XX'_`l'_`j'_`i'
 replace combined_pl`=increase_XX'_temp_`l'_`i'_XX=combined_pl`=increase_XX'_temp_`l'_`i'_XX+combined_pl`=increase_XX'_temp_`l'_`j'_`i'_XX
 } 
 
-replace part2_pl_switch`=increase_XX'_`i'_XX=part2_pl_switch`=increase_XX'_`i'_XX+combined_pl`=increase_XX'_temp_`l'_`i'_XX if d_sq_int_XX==`l' 
+replace part2_pl_switch`=increase_XX'_`i'_XX=part2_pl_switch`=increase_XX'_`i'_XX+combined_pl`=increase_XX'_temp_`l'_`i'_XX
 } // MODIF FELIX
 } // end loop oveer l
 


### PR DESCRIPTION
1. Add minus sign when initializing the U_Gg_var for switchers out
2. Drop the "if d_sq_int_XX==`l'" condition when we sum the parts across baseline treatment levels for the placebo variances