### PR TITLE
Fix for the by_path() bug

### DIFF
--- a/Stata/prior_versions/did_multiplegt_dyn_09_06_25.ado
+++ b/Stata/prior_versions/did_multiplegt_dyn_09_06_25.ado
@@ -322,12 +322,6 @@ if scalar(aggregated_data)==0{
 	replace weight_XX=0 if tag_y_miss_XX==1
 }
 	
-//// Modif Felix 26.05.2025 -> tempvar to use the correct weights when we use by_path and the data is collapsed becausee the group variable is coarser than the panel identifier
-if "`by_path'" != ""{
-	tempvar weight_path_XX
-	generate `weight_path_XX' = weight_XX
-}	
-	
 ///// by option for heterogeneous treatment effects analysis
 
 // define local so we run the loop once if by is not specified
@@ -1289,8 +1283,8 @@ global l_placebo_graph_XX=`=-l_placebo_XX'
 
 capture graph drop graph_`k'_XX
 
-// call did_multiplegt_dyn with the corresponding options // Modif Felix 26.05.2025 -> change the weight to the tempvar
-noisily did_multiplegt_dyn `1' `2' `3' `4' if (different_paths_XX==`k'|cont_path_alt_XX==1), effects(`=l_XX') placebo(`=l_placebo_XX') same_switchers switchers(`switchers') `only_never_switchers' controls(`controls') trends_nonparam(`trends_nonparam') weight(`weight_path_XX') `dont_drop_larger_lower' `normalized' cluster(`cluster') `same_switchers_pl' `trends_lin' by(`by_var_path') predict_het(`predict_het') ci_level(`ci_level') design(`design') date_first_switch(`date_first_switch') continuous(`continuous') `less_conservative_se' `normalized_weights' `graph_off' `save_sample' graphoptions(xlabel(`=-l_placebo_XX'[1]`=l_XX') title(Treatment path (${path_`k'_XX}); ${num_g_path_`k'_XX} switchers, size(small)) xtitle(Relative time to last period before treatment changes (t=0), size(small)) graphregion(color(white)) plotregion(color(white)) legend(pos(6) order(`graph_options_int') rows(1) size(small)) name(graph_`k'_XX) legend(off))
+// call did_multiplegt_dyn with the corresponding options
+noisily did_multiplegt_dyn `1' `2' `3' `4' if (different_paths_XX==`k'|cont_path_alt_XX==1), effects(`=l_XX') placebo(`=l_placebo_XX') same_switchers switchers(`switchers') `only_never_switchers' controls(`controls') trends_nonparam(`trends_nonparam') weight(`weight') `dont_drop_larger_lower' `normalized' cluster(`cluster') `same_switchers_pl' `trends_lin' by(`by_var_path') predict_het(`predict_het') ci_level(`ci_level') design(`design') date_first_switch(`date_first_switch') continuous(`continuous') `less_conservative_se' `normalized_weights' `graph_off' `save_sample' graphoptions(xlabel(`=-l_placebo_XX'[1]`=l_XX') title(Treatment path (${path_`k'_XX}); ${num_g_path_`k'_XX} switchers, size(small)) xtitle(Relative time to last period before treatment changes (t=0), size(small)) graphregion(color(white)) plotregion(color(white)) legend(pos(6) order(`graph_options_int') rows(1) size(small)) name(graph_`k'_XX) legend(off))
 
 // Save global with all the graph names to do the combine 
 global graph_by_path "$graph_by_path graph_`k'_XX"


### PR DESCRIPTION
Added a tempvar for the weight variable to fix the bug that would arise when by_path is specified in a dataset where the treatment is administered at a coarser level than the panel identifier (i.e. cases where the datase needs to be collapsed).