### PR TITLE
Fixed backward compatibility issue with predict_het

### DIFF
--- a/Stata/did_multiplegt_dyn.ado
+++ b/Stata/did_multiplegt_dyn.ado
@@ -9,7 +9,7 @@
 ** Subsections may contain unnumbered subsubsections, tagged with "//".
 ** Subsubsections may be further divided into paragraphs, tagged with "*".
 ** Comments are also tagged with "*".
-** This version : July 2nd, 2025
+** This version : December 31st, 2025
 
 ** This version includes Diego's changes:
 **** Fixes to variance estimation with controls() (tks)

--- a/Stata/did_multiplegt_dyn.sthlp
+++ b/Stata/did_multiplegt_dyn.sthlp
@@ -822,6 +822,23 @@ estimators with Y' as the outcome.
 Yes, it can, see Section 1.7 of the Web Appendix of de Chaisemartin and D'Haultfoeuille (2024) for further details.
 {p_end}
 
+{p 4 4}
+{it:Instead of using an F-test to jointly test that all placebos or all effects are zero, I would like to use a sup t-test. Is this possible?}
+{p_end}
+
+{p 4 4}
+Yes, {cmd:did_multiplegt_dyn} is compatible with
+the {cmd:sotable} package. Here's how to produce 
+sup t-tests on all placebos and effects
+in post estimation:
+{p_end}
+
+{phang2}{stata net get did_multiplegt_dyn}{p_end}
+{phang2}{stata use favara_imbs_did_multiplegt_dyn.dta, clear}{p_end}
+{phang2}{stata did_multiplegt_dyn Dl_vloans_b county year inter_bra, effects(8) placebo(3) cluster(state_n) graph_off}{p_end}
+{phang2}{stata sotable, pnames(`=e(placebo)') normal}{p_end}
+{phang2}{stata sotable, pnames(`=e(effects)') normal}{p_end}
+
 {title:References}
 
 {p 4 8}


### PR DESCRIPTION
Fixed backward compatibility issue with predict_het: _r_lb/_r_ub replaced with explicit CI formulas + fixed bug to ereturn of predict_het tables